### PR TITLE
feat(kms): add KmsStack for SOPS key management

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { IamStack } from './stacks/iam-stack';
-import { StorageStack } from './stacks/storage-stack';
 import { KmsStack } from './stacks/kms-stack';
+import { StorageStack } from './stacks/storage-stack';
+
 
 const app = new cdk.App();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,14 @@
 import * as cdk from 'aws-cdk-lib';
 import { IamStack } from './stacks/iam-stack';
 import { StorageStack } from './stacks/storage-stack';
+import { KmsStack } from './stacks/kms-stack';
 
 const app = new cdk.App();
 
 const env = { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION };
 
 new IamStack(app, 'IamStack', { env });
+new KmsStack(app, 'KmsStack', { env });
 new StorageStack(app, 'StorageStack', { env });
 
 app.synth();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import { IamStack } from './stacks/iam-stack';
 import { KmsStack } from './stacks/kms-stack';
 import { StorageStack } from './stacks/storage-stack';
 
-
 const app = new cdk.App();
 
 const env = { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION };

--- a/src/stacks/kms-stack.ts
+++ b/src/stacks/kms-stack.ts
@@ -13,7 +13,7 @@ export class KmsStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
 
-    new cdk.CfnOutput(this, 'SopsKeyArn', {      
+    new cdk.CfnOutput(this, 'SopsKeyArn', {
       value: terraformSopsKey.key.keyArn,
       description: 'ARN of the KMS key for Terraform SOPS encryption',
     });

--- a/src/stacks/kms-stack.ts
+++ b/src/stacks/kms-stack.ts
@@ -1,0 +1,26 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { KmsKeyResource } from './security/kms-key-resource';
+
+export class KmsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const terraformSopsKey = new KmsKeyResource(this, 'SopsKey', {
+      alias: 'SopsKey',
+      description: 'KMS key for SOPS encryption',
+      enableKeyRotation: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    new cdk.CfnOutput(this, 'SopsKeyArn', {      
+      value: terraformSopsKey.key.keyArn,
+      description: 'ARN of the KMS key for Terraform SOPS encryption',
+    });
+
+    new cdk.CfnOutput(this, 'SopsKeyId', {
+      value: terraformSopsKey.key.keyId,
+      description: 'ID of the KMS key for Terraform SOPS encryption',
+    });
+  }
+}

--- a/src/stacks/security/kms-key-resource.ts
+++ b/src/stacks/security/kms-key-resource.ts
@@ -1,0 +1,25 @@
+import * as cdk from 'aws-cdk-lib';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import { Construct } from 'constructs';
+
+export interface KmsKeyProps {
+  readonly alias?: string;
+  readonly description?: string;
+  readonly enableKeyRotation?: boolean;
+  readonly removalPolicy?: cdk.RemovalPolicy;
+}
+
+export class KmsKeyResource extends Construct {
+  public readonly key: kms.Key;
+
+  constructor(scope: Construct, id: string, props: KmsKeyProps = {}) {
+    super(scope, id);
+
+    this.key = new kms.Key(this, 'Default', {
+      alias: props.alias,
+      description: props.description,
+      enableKeyRotation: props.enableKeyRotation ?? true,
+      removalPolicy: props.removalPolicy ?? cdk.RemovalPolicy.RETAIN,
+    });
+  }
+}


### PR DESCRIPTION
This PR introduces a new `KmsStack` to provision and manage a customer-managed KMS key. The key is specifically intended for use with SOPS (Secrets OPerationS) to encrypt and decrypt secrets.

The new stack utilizes the `KmsKeyResource` construct to create a KMS key with the following configuration:
- An alias of 'SopsKey' for easy identification.
- Key rotation enabled to enhance security.
- A removal policy of RETAIN to prevent accidental deletion of the key and loss of encrypted data.

The stack exports the key's ARN and ID as CloudFormation outputs, making it easy to reference in other applications, CI/CD pipelines, or Terraform configurations.